### PR TITLE
Fix LNURLw on payment failure

### DIFF
--- a/lnurl.py
+++ b/lnurl.py
@@ -142,20 +142,20 @@ async def api_lnurlw_callback(
         return {"status": "ERROR", "reason": "spent"}
     paylink = await get_satsdice_pay(link.satsdice_pay)
 
-    if paylink:
-        await update_satsdice_withdraw(link.id, used=1)
-        try:
-            await pay_invoice(
-                wallet_id=paylink.wallet,
-                payment_request=pr,
-                max_sat=link.value,
-                extra={"tag": "withdraw"},
-            )
-            # If no exception was raised, it means payment was successful
-            return {"status": "OK"}
-        except PaymentFailure as e:
-            # If the payment failed, we need to reset the withdraw to unused
-            await update_satsdice_withdraw(link.id, used=0)
-            return {"status": "ERROR", "reason": str(e)}
+    if not paylink:
+        return {"status": "ERROR", "reason": "no paylink found"}
 
-    return {"status": "ERROR", "reason": "no paylink found"}
+    await update_satsdice_withdraw(link.id, used=1)
+    try:
+        await pay_invoice(
+            wallet_id=paylink.wallet,
+            payment_request=pr,
+            max_sat=link.value,
+            extra={"tag": "withdraw"},
+        )
+        # If no exception was raised, it means payment was successful
+        return {"status": "OK"}
+    except PaymentFailure as e:
+        # If the payment failed, we need to reset the withdraw to unused
+        await update_satsdice_withdraw(link.id, used=0)
+        return {"status": "ERROR", "reason": str(e)}

--- a/lnurl.py
+++ b/lnurl.py
@@ -143,6 +143,7 @@ async def api_lnurlw_callback(
     paylink = await get_satsdice_pay(link.satsdice_pay)
 
     if paylink:
+        await update_satsdice_withdraw(link.id, used=1)
         try:
             await pay_invoice(
                 wallet_id=paylink.wallet,
@@ -151,10 +152,10 @@ async def api_lnurlw_callback(
                 extra={"tag": "withdraw"},
             )
             # If no exception was raised, it means payment was successful
-            await update_satsdice_withdraw(link.id, used=1)
             return {"status": "OK"}
         except PaymentFailure as e:
-            # Handle the payment failure, log the error or take appropriate action
+            # If the payment failed, we need to reset the withdraw to unused
+            await update_satsdice_withdraw(link.id, used=0)
             return {"status": "ERROR", "reason": str(e)}
 
     return {"status": "ERROR", "reason": "no paylink found"}


### PR DESCRIPTION
If payment fails to succeed, set `used` back to false. Currently, the used column on the satsdice was set to true but if payment fails for whatever reason, the LNURLw is disabled and can't be used again.

This PR sets the used back to false if the payment fails.